### PR TITLE
:bug: bugfix: fix path installed difference base on mac chips

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -9,16 +9,17 @@ import type { Options } from './types';
 
 const exec = util.promisify(childProcess.exec);
 
-const defaultOptions: Required<Options> = {
+const defaultOptions = async (): Promise<Required<Options>> => ({
   compatibilityLevel: 1.4,
   resolution: 'ebook',
   imageQuality: 100,
-  gsModule: getBinPath(os.platform()),
+  gsModule: await getBinPath(os.platform()),
   pdfPassword: '',
   removePasswordAfterCompression: false,
-};
+});
 
 async function compress(file: string | Buffer, options?: Options) {
+  const resolvedDefaultOptions = await defaultOptions();
   const {
     resolution,
     imageQuality,
@@ -26,7 +27,7 @@ async function compress(file: string | Buffer, options?: Options) {
     gsModule,
     pdfPassword,
     removePasswordAfterCompression,
-  } = defaults(options, defaultOptions);
+  } = defaults(options, resolvedDefaultOptions);
 
   const output = path.resolve(os.tmpdir(), Date.now().toString());
 

--- a/src/get-bin-path.ts
+++ b/src/get-bin-path.ts
@@ -1,18 +1,44 @@
-function getBinPath(platform: NodeJS.Platform) {
+import { exec } from 'node:child_process';
+import utils from 'node:util';
+
+const execAsync = utils.promisify(exec);
+
+async function getDarwinBinPath(): Promise<string> {
+  let gsBinPath: string;
+  try {
+    const { stdout } = await execAsync('which gs');
+    if (stdout.startsWith('/opt/homebrew/bin')) {
+      gsBinPath = '/opt/homebrew/bin/gs';
+    } else if (stdout.startsWith('/usr/local/bin')) {
+      gsBinPath = '/usr/local/bin/gs';
+    } else {
+      gsBinPath = stdout.trim();
+    }
+  } catch (e) {
+    return 'fail to get gs bin path';
+  }
+
+  return gsBinPath;
+}
+
+async function getBinPath(platform: NodeJS.Platform) {
   if (platform === 'linux') {
-    return '/usr/bin/gs';
+    return Promise.resolve('/usr/bin/gs');
   }
 
   if (platform === 'win32') {
-    return 'gswin64c';
+    return Promise.resolve('/usr/bin/gs');
   }
 
   if (platform === 'darwin') {
-    return '/usr/local/bin/gs';
+    const path = await getDarwinBinPath();
+    return path;
   }
 
-  throw new Error(
-    'not possible to get binaries path, unsupported platform was provided'
+  return Promise.reject(
+    new Error(
+      'not possible to get binaries path, unsupported platform was provided'
+    )
   );
 }
 


### PR DESCRIPTION
On Macos, the gs bin path could be installed either on "/opt/homebrew/bin/gs" or "/usr/local/bin/gs" base on the chips. Add a command "which gs" to decide the final bin path.