### PR TITLE
Homebrew path

### DIFF
--- a/src/compress.ts
+++ b/src/compress.ts
@@ -3,7 +3,7 @@ import util from 'util';
 import fs from 'fs';
 import os from 'os';
 import childProcess from 'child_process';
-import { defaults } from 'lodash';
+import defaults from 'lodash/defaults';
 import getBinPath from './get-bin-path';
 import type { Options } from './types';
 

--- a/src/get-bin-path.ts
+++ b/src/get-bin-path.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'fs';
+
 function getBinPath(platform: NodeJS.Platform) {
   if (platform === 'linux') {
     return '/usr/bin/gs';
@@ -8,7 +10,9 @@ function getBinPath(platform: NodeJS.Platform) {
   }
 
   if (platform === 'darwin') {
-    return '/usr/local/bin/gs';
+    const brewPath = '/opt/homebrew/bin/gs';
+    const defaultPath = '/usr/local/bin/gs';
+    return existsSync(brewPath) ? brewPath : defaultPath;
   }
 
   throw new Error(


### PR DESCRIPTION
This PR adds support for Homebrew installations on macOS by checking /opt/homebrew/bin/gs while retaining the system-wide installation path