### PR TITLE
chore: Ghostscript tar.xz bundles and v0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compress-pdf",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "templateVersion": "1.3.0",
   "description": "A PDF compression library using Ghostscript",
   "main": "dist/index.js",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -12,7 +12,8 @@ const { Readable } = require('stream');
 const { pipeline } = require('stream/promises');
 const { execSync } = require('child_process');
 
-const BASE_URL = 'https://github.com/victorsoares96/compress-pdf/releases/download';
+const BASE_URL =
+  'https://github.com/victorsoares96/compress-pdf/releases/download';
 
 // Environment variables to control installation
 const SKIP_DOWNLOAD = process.env.COMPRESS_PDF_SKIP_DOWNLOAD === 'true';
@@ -23,22 +24,22 @@ const CUSTOM_BIN_PATH = process.env.COMPRESS_PDF_BIN_PATH;
  */
 function getDownloadUrl() {
   const platform = process.platform;
-  
+
   let filename;
   switch (platform) {
     case 'darwin':
-      filename = 'ghostscript_darwin.zip';
+      filename = 'ghostscript_darwin.tar.xz';
       break;
     case 'linux':
-      filename = 'ghostscript_linux.zip';
+      filename = 'ghostscript_linux.tar.xz';
       break;
     case 'win32':
-      filename = 'ghostscript_windows.zip';
+      filename = 'ghostscript_windows.tar.xz';
       break;
     default:
       throw new Error(`Unsupported platform: ${platform}`);
   }
-  
+
   return `${BASE_URL}/binaries/${filename}`;
 }
 
@@ -47,58 +48,98 @@ function getDownloadUrl() {
  */
 async function downloadFile(url, destination) {
   console.log(`📦 Downloading Ghostscript binaries from ${url}...`);
-  
+
   const response = await fetch(url);
-  
+
   if (!response.ok) {
-    throw new Error(`Failed to download: HTTP ${response.status} ${response.statusText}`);
+    throw new Error(
+      `Failed to download: HTTP ${response.status} ${response.statusText}`
+    );
   }
-  
+
   // Convert Web Stream to Node Stream
   const nodeStream = Readable.fromWeb(response.body);
   const fileStream = fs.createWriteStream(destination);
-  
+
   await pipeline(nodeStream, fileStream);
-  
+
   console.log(`✅ Download completed: ${destination}`);
 }
 
 /**
- * Extract ZIP file using platform-specific commands
+ * Extract a .tar.xz archive using the system tar command with a Python fallback.
  */
-async function extractZip(zipPath, outputDir) {
+async function extractArchive(archivePath, outputDir) {
   console.log(`📂 Extracting archive to ${outputDir}...`);
-  
-  // Ensure output directory exists
+
   if (!fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir, { recursive: true });
   }
-  
-  const platform = process.platform;
-  
+
+  // tar -xJf works on Linux, macOS, and Windows 10+ (build 17063+)
   try {
-    if (platform === 'win32') {
-      // Windows: Use PowerShell's Expand-Archive
-      const command = `powershell -NoProfile -Command "& { Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('${zipPath.replace(/\\/g, '\\\\')}', '${outputDir.replace(/\\/g, '\\\\')}') }"`;
-      execSync(command, { stdio: 'pipe' });
-    } else {
-      // Unix-like: Use unzip command if available, otherwise try tar
-      try {
-        execSync(`unzip -o "${zipPath}" -d "${outputDir}"`, { stdio: 'pipe' });
-      } catch (unzipError) {
-        // If unzip is not available, try using Python as a fallback
-        const pythonCommand = `python3 -c "import zipfile; zipfile.ZipFile('${zipPath}').extractall('${outputDir}')"`;
-        execSync(pythonCommand, { stdio: 'pipe' });
-      }
+    execSync(`tar -xJf "${archivePath}" -C "${outputDir}"`, { stdio: 'pipe' });
+    console.log('✅ Extraction completed');
+    return;
+  } catch (_) {
+    // fall through to Python fallback
+  }
+
+  // Python fallback (lzma + tarfile are in stdlib since Python 3.3)
+  try {
+    const py = `
+import tarfile, os
+with tarfile.open(r'${archivePath.replace(/\\/g, '\\\\')}', 'r:xz') as t:
+    t.extractall(r'${outputDir.replace(/\\/g, '\\\\')}')
+`.trim();
+    const pythonBin = process.platform === 'win32' ? 'python' : 'python3';
+    execSync(
+      `${pythonBin} -c "${py.replace(/"/g, '\\"').replace(/\n/g, ' ')}"`,
+      { stdio: 'pipe' }
+    );
+    console.log('✅ Extraction completed (Python fallback)');
+    return;
+  } catch (err) {
+    throw new Error(
+      'Failed to extract .tar.xz archive. ' +
+        'Ensure tar (with xz support) or Python 3 is available.\n' +
+        err.message
+    );
+  }
+}
+
+/**
+ * Smoke-test the gs binary on Linux to catch missing shared library errors
+ * early and surface a clear message to the user.
+ */
+function checkLinuxDependencies(binDir) {
+  if (process.platform !== 'linux') return;
+
+  const gsBin = path.join(binDir, 'bin', 'gs');
+  if (!fs.existsSync(gsBin)) return;
+
+  try {
+    execSync(`"${gsBin}" --version`, { stdio: 'pipe', timeout: 5000 });
+    console.log('✅ Ghostscript dependency check passed');
+  } catch (testError) {
+    const stderr = testError.stderr ? testError.stderr.toString() : '';
+    const missingLib = stderr.match(
+      /error while loading shared libraries: ([^\s:]+)/
+    );
+
+    if (missingLib) {
+      const libName = missingLib[1];
+      console.warn(`⚠️  Missing shared library: ${libName}`);
+      console.warn(`   Please install it and re-run npm install.`);
+      console.warn(
+        `   Example: sudo apt-get install -y ${libName.split('.so')[0].replace(/^lib/, 'lib')}`
+      );
+      console.warn(
+        `   Or set COMPRESS_PDF_SKIP_DOWNLOAD=true to use a system Ghostscript instead.`
+      );
+    } else if (stderr) {
+      console.warn('⚠️  Ghostscript binary test failed:', stderr.trim());
     }
-    console.log(`✅ Extraction completed`);
-  } catch (error) {
-    console.error('❌ Failed to extract archive:', error.message);
-    console.error('\n💡 Trying alternative extraction method...');
-    
-    // Fallback: Try using Node.js built-in modules (requires yauzl or similar)
-    // For now, we'll just throw the error
-    throw new Error('Failed to extract ZIP archive. Please ensure you have unzip (Linux/Mac) or PowerShell (Windows) available.');
   }
 }
 
@@ -107,12 +148,12 @@ async function extractZip(zipPath, outputDir) {
  */
 function setExecutablePermissions(binDir) {
   const platform = process.platform;
-  
+
   if (platform !== 'win32') {
     try {
       // Find all files in the bin directory and make them executable
       const files = fs.readdirSync(binDir, { recursive: true });
-      files.forEach(file => {
+      files.forEach((file) => {
         const filePath = path.join(binDir, file);
         if (fs.statSync(filePath).isFile()) {
           fs.chmodSync(filePath, 0o755);
@@ -141,21 +182,23 @@ function cleanup(filePath) {
 async function install() {
   // Check if download should be skipped
   if (SKIP_DOWNLOAD) {
-    console.log('⏭️  Skipping Ghostscript download (COMPRESS_PDF_SKIP_DOWNLOAD=true)');
+    console.log(
+      '⏭️  Skipping Ghostscript download (COMPRESS_PDF_SKIP_DOWNLOAD=true)'
+    );
     return;
   }
-  
+
   if (CUSTOM_BIN_PATH) {
     console.log(`⏭️  Using custom binary path: ${CUSTOM_BIN_PATH}`);
     return;
   }
-  
+
   try {
     // Determine paths
     const rootDir = path.resolve(__dirname, '..');
     const binDir = path.join(rootDir, 'bin', 'gs');
-    const tempZipPath = path.join(rootDir, 'ghostscript_temp.zip');
-    
+    const tempZipPath = path.join(rootDir, 'ghostscript_temp.tar.xz');
+
     // Check if binaries already exist
     const platform = process.platform;
     let binaryName;
@@ -164,45 +207,53 @@ async function install() {
     } else {
       binaryName = 'gs';
     }
-    
+
     // Check in bin subdirectory (extracted structure)
     let expectedBinaryPath = path.join(binDir, 'bin', binaryName);
     if (!fs.existsSync(expectedBinaryPath)) {
       // Also check in root of gs directory
       expectedBinaryPath = path.join(binDir, binaryName);
     }
-    
+
     if (fs.existsSync(expectedBinaryPath)) {
       console.log('✅ Ghostscript binaries already installed');
       console.log(`📍 Location: ${binDir}`);
       return;
     }
-    
+
     // Get download URL
     const downloadUrl = getDownloadUrl();
-    
+
     // Download the archive
     await downloadFile(downloadUrl, tempZipPath);
-    
+
     // Extract the archive
-    await extractZip(tempZipPath, binDir);
-    
+    await extractArchive(tempZipPath, binDir);
+
     // Set executable permissions on Unix-like systems
     setExecutablePermissions(binDir);
-    
+
+    // Fix missing shared library dependencies on Linux (e.g. libidn.so.11)
+    checkLinuxDependencies(binDir);
+
     // Clean up
     cleanup(tempZipPath);
-    
+
     console.log('🎉 Ghostscript binaries installed successfully!');
     console.log(`📍 Location: ${binDir}`);
-    
   } catch (error) {
     console.error('❌ Failed to install Ghostscript binaries:', error.message);
-    console.error('\n⚠️  You can skip this step by setting COMPRESS_PDF_SKIP_DOWNLOAD=true');
-    console.error('⚠️  Or provide a custom binary path with COMPRESS_PDF_BIN_PATH');
+    console.error(
+      '\n⚠️  You can skip this step by setting COMPRESS_PDF_SKIP_DOWNLOAD=true'
+    );
+    console.error(
+      '⚠️  Or provide a custom binary path with COMPRESS_PDF_BIN_PATH'
+    );
     console.error('\n📖 For manual installation instructions, see:');
-    console.error('   https://github.com/victorsoares96/compress-pdf/blob/master/README.md');
-    
+    console.error(
+      '   https://github.com/victorsoares96/compress-pdf/blob/master/README.md'
+    );
+
     // Don't fail the installation, just warn
     process.exit(0);
   }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -94,7 +94,10 @@ with tarfile.open(r'${archivePath.replace(/\\/g, '\\\\')}', 'r:xz') as t:
 `.trim();
     const pythonBin = process.platform === 'win32' ? 'python' : 'python3';
     execSync(
-      `${pythonBin} -c "${py.replace(/"/g, '\\"').replace(/\n/g, ' ')}"`,
+      `${pythonBin} -c "${py
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(/\r?\n/g, ' ')}"`,
       { stdio: 'pipe' }
     );
     console.log('✅ Extraction completed (Python fallback)');

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -135,7 +135,7 @@ function checkLinuxDependencies(binDir) {
       console.warn(`⚠️  Missing shared library: ${libName}`);
       console.warn(`   Please install it and re-run npm install.`);
       console.warn(
-        `   Example: sudo apt-get install -y ${libName.split('.so')[0].replace(/^lib/, 'lib')}`
+        `   Example: sudo apt-get install -y ${libName.split('.so')[0]}`
       );
       console.warn(
         `   Or set COMPRESS_PDF_SKIP_DOWNLOAD=true to use a system Ghostscript instead.`


### PR DESCRIPTION
## Summary

- Bump package version to **0.6.3**.
- Update `scripts/install.js` to download and extract **`.tar.xz`** Ghostscript bundles instead of **`.zip`** (Linux, macOS, Windows).
- Extraction uses `tar -xJf` when available, with a Python `tarfile` fallback.

## Ghostscript release assets (not in this PR)

Optimized bundles were produced locally and should be uploaded to the GitHub release before publishing:

| Platform | Before (zip) | After (tar.xz) | Reduction |
|----------|--------------|----------------|-----------|
| Linux | 77.6 MB | 30.1 MB | ~61% |
| macOS | 43.6 MB | 7.0 MB | ~84% |
| Windows | 21.8 MB | 14.2 MB | ~35% |

Linux bundle also drops GUI-only deps (icons, GTK/X11 stack) while keeping `libidn` intact. macOS bundle drops PCL/XPS tools not needed for PDF compression.

## Test plan

- [ ] Upload `ghostscript_linux.tar.xz`, `ghostscript_darwin.tar.xz`, and `ghostscript_windows.tar.xz` to the `v0.6.3` (or `binaries`) GitHub release
- [ ] Run `npm install` on Linux, macOS, and Windows and confirm Ghostscript extracts and `gs --version` works
- [ ] Run `npm test` after install

Made with [Cursor](https://cursor.com)