### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish


### PR DESCRIPTION
Potential fix for [https://github.com/victorsoares96/compress-pdf/security/code-scanning/31](https://github.com/victorsoares96/compress-pdf/security/code-scanning/31)

Add an explicit `permissions` block to `.github/workflows/publish.yml` so the workflow does not inherit potentially broad default token scopes.

Best fix (without changing behavior): define workflow-level permissions with the minimal required scope:
- `contents: read`

This supports `actions/checkout` and keeps token privileges constrained. Place the block near the top level (after `on:` and before `jobs:`), so it applies to all jobs unless overridden later.

No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
