### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,6 +7,9 @@ on:
       - 'LICENSE'
       - '.editorconfig'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: "Validate"


### PR DESCRIPTION
Potential fix for [https://github.com/victorsoares96/compress-pdf/security/code-scanning/30](https://github.com/victorsoares96/compress-pdf/security/code-scanning/30)

Add an explicit `permissions` block to `.github/workflows/pull-request.yml` at the workflow root level (right after `on:` section, before `jobs:`).  
For this pipeline, a least-privilege baseline is:

- `contents: read` (required for checkout/read repository content)

No shown step requires GitHub write scopes (publishing uses `NPM_TOKEN`, coverage upload uses `CODECOV_TOKEN`), so we should not grant extra permissions unless needed. This preserves functionality while removing implicit/default token privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
